### PR TITLE
修复'gbk'编码出错，FIXME: UnicodeDecodeError: 'gbk' codec can't decode byte 0xb0 in posi…

### DIFF
--- a/youtube_dl/options.py
+++ b/youtube_dl/options.py
@@ -41,7 +41,8 @@ def _hide_login_info(opts):
 def parseOpts(overrideArguments=None):
     def _readOptions(filename_bytes, default=[]):
         try:
-            optionf = open(filename_bytes)
+            # FIXME: UnicodeDecodeError: 'gbk' codec can't decode byte 0xb0 in position 112: illegal multibyte sequence
+            optionf = open(filename_bytes, 'r', encoding='UTF-8')
         except IOError:
             return default  # silently skip if file is not present
         try:


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x ] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x ] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [ ] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [x ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [ ] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x ] Bug fix
- [ ] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

修复'gbk'编码出错
FIXME: UnicodeDecodeError: 'gbk' codec can't decode byte 0xb0 in position 112: illegal multibyte sequence

所有操作以及错误信息如下所示：
All operations and error messages are as follows:

```
C:\Users\Administrator\Downloads>youtube-dl.exe --version
2020.01.01

C:\Users\Administrator\Downloads>youtube-dl.exe "https://www.youtube.com/watch?v=2jZFsQS8Veo"
Traceback (most recent call last):
  File "__main__.py", line 19, in <module>
  File "C:\Users\dst\AppData\Roaming\Build archive\youtube-dl\ytdl-org\tmpj4acy7ln\build\youtube_dl\__init__.py", line 474, in main
  File "C:\Users\dst\AppData\Roaming\Build archive\youtube-dl\ytdl-org\tmpj4acy7ln\build\youtube_dl\__init__.py", line 58, in _real_main
  File "C:\Users\dst\AppData\Roaming\Build archive\youtube-dl\ytdl-org\tmpj4acy7ln\build\youtube_dl\options.py", line 904, in parseOpts
  File "C:\Users\dst\AppData\Roaming\Build archive\youtube-dl\ytdl-org\tmpj4acy7ln\build\youtube_dl\options.py", line 83, in _readUserConf
  File "C:\Users\dst\AppData\Roaming\Build archive\youtube-dl\ytdl-org\tmpj4acy7ln\build\youtube_dl\options.py", line 49, in _readOptions
UnicodeDecodeError: 'gbk' codec can't decode byte 0xb0 in position 112: illegal multibyte sequence
```
